### PR TITLE
Add an option to use hardlinks instead of symlinks

### DIFF
--- a/gphotos/Main.py
+++ b/gphotos/Main.py
@@ -162,6 +162,11 @@ class GooglePhotosSyncMain:
         action='store_true',
         help="Scrape the Google Photos website for location metadata"
              " and add it to the local files' EXIF metadata")
+    parser.add_argument(
+        "--use-hardlinks",
+        action='store_true',
+        help="Use hardlinks instead of symbolic links in albums and comparison"
+             " folders")
     parser.add_help = True
 
     def setup(self, args: Namespace, db_path: Path):
@@ -201,7 +206,8 @@ class GooglePhotosSyncMain:
         self.google_albums_sync = GoogleAlbumsSync(
             self.google_photos_client, root_folder, self.data_store,
             args.flush_index or args.retry_download or args.rescan,
-            photos_folder, albums_folder, args.use_flat_path)
+            photos_folder, albums_folder, args.use_flat_path,
+            args.use_hardlinks)
         self.location_update = LocationUpdate(root_folder, self.data_store,
                                               args.photos_path)
         if args.compare_folder:


### PR DESCRIPTION
This PR adds the `--use-hardlinks` option to create hardlinks instead of symlinks in the `albums/` and comparison directory structures.

It can't create hardlinks if the photo has not been downloaded though, so that's a different behavior compared to the symlink option, that can create symlinks to non-existent files.

And this doesn't take into account the case where a first pass is run with symlinks, and a subsequent one with hardlinks, or vice versa. I guess the option should be recorded in the DB during the first execution, and kept as a reference, otherwise, one could end up with a mix of hardlinks and symlinks in the same `albums/` tree.

So, there's still some work to do :)