### PR TITLE
Build docker from pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.7-buster
+
+RUN mkdir -p /root/.config /config
+RUN ln -s /config /root/.config/gphotos-sync 
+VOLUME /config
+
+RUN mkdir /storage
+VOLUME /storage
+
+RUN pip install gphotos-sync
+
+ENTRYPOINT [ "gphotos-sync" ]

--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,31 @@ For a description of additional command line parameters type::
 
   gphotos-sync --help
 
+Running with docker
+------------------
+
+You can run the tool from the container using [prebuilt Docker image](https://hub.docker.com/r/gilesknap/gphotos-sync). The container
+has a 2 mount points:
+- `/storage` - this is where your photos will be stored. You can mount single directory, or
+multiple subdirectories in case you want to backup multiple accounts
+- `/config` - the directory that contains `client_secret.json` file
+
+```
+docker run \
+  -ti \
+  --name gphotos-sync \
+  -v /YOUR_LOCAL/PATH/TO_PHOTOS:/storage \
+  -v /YOUR_LOCAL/PATH/TO_CONFIG:/config \
+  gilesknap/gphotos-sync
+  /storage
+```
+
+To remove the container (for instance if you want to run it on scheduled basis and do a cleanup):
+
+```
+docker rm -f $(docker ps --filter name=gphotos-sync -qa) 2> /dev/null
+```
+
 
 Appendix
 ========

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+command -v docker >/dev/null 2>&1 || { echo >&2 "Docker CLI is required."; exit 1; }
+[[ -z "${DOCKER_USERNAME}" ]] || { echo >&2 "DOCKER_USERNAME is not set."; exit 1; }
+[[ -z "${DOCKER_PASSWORD}" ]] || { echo >&2 "DOCKER_PASSWORD is not set."; exit 1; }
+
+docker build . \
+    -t gilesknap/gphotos-sync:latest \
+    -f ./Dockerfile
+
+docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+docker push gilesknap/gphotos-sync


### PR DESCRIPTION
This will add some support for running the tool from container. I tested it locally and it works nicely. Things that still needs to be improved:
* I think it is better to build from source and not by pulling library from PIP
* I can add explanation later how to setup cron to run container on scheduled basis

Things to do for maintainer:
* You will need to create repository on DockerHub with name `gphotos-sync` (I linked in readme)
* If you want to push a release to DockerHub inside you CD pipeline (Travis), you will need to execute `build-docker.sh` during deploy step. This script expects credentials to docker registry. Alternatively people can just build manually locally.

Related discussion: #105 