### PR TITLE
fix #110: using download dir to get the minimum date

### DIFF
--- a/gphotos/Utils.py
+++ b/gphotos/Utils.py
@@ -3,7 +3,7 @@
 import re
 from datetime import datetime
 from tempfile import NamedTemporaryFile
-from os import utime, unlink
+from os import utime, unlink, getcwd
 import logging
 
 log = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ def maximum_date() -> datetime:
 def minimum_date() -> datetime:
     global MINIMUM_DATE
     if MINIMUM_DATE is None:
-        with NamedTemporaryFile() as t:
+        with NamedTemporaryFile(dir=getcwd()) as t:
             # determine the minimum date that is usable on the
             # current platform (is there a better way to do this?)
             min_dates = (1800, 1900, 1970, 1971, 1980)


### PR DESCRIPTION
The temp file should be in the directory where we download the images because in that way we will have the correct value even if it's a mount point.