### PR TITLE
Log failed request status code and contents.

### DIFF
--- a/gphotos/restclient.py
+++ b/gphotos/restclient.py
@@ -83,7 +83,12 @@ class Method:
             timeout=10,
             params=query_args)
 
-        result.raise_for_status()
+        try:
+            result.raise_for_status()
+        except:
+            log.error('Request failed with status {}: {}'.format(
+                result.status_code, result.content))
+            raise
         return result
 
     def make_path(self, path_args: Dict[str, str]) -> str:


### PR DESCRIPTION
Photos api has some informative error messages in it. Print them out
on failure.

I did this while debugging my own configuration, and it helpfully told me that I hadn't enabled the Photos API for my application.