### PR TITLE
Handle FileExistsError in case insensitive filesystem check

### DIFF
--- a/gphotos/Checks.py
+++ b/gphotos/Checks.py
@@ -107,7 +107,7 @@ class Checks:
                 raise ValueError("separate case files not seen")
             case_file.unlink()
             no_case_file.unlink()
-        except (FileNotFoundError, ValueError):
+        except (FileExistsError, FileNotFoundError, ValueError):
             log.info("Case insensitive file system found")
         else:
             log.info("Case sensitive file system found")


### PR DESCRIPTION
```
PS C:\Users\xxx> docker run --rm -it -v C:\Users\xxx\gphoto-sync\pictures:/storage -v C:\Users\xxx\gphoto-sync\config\client_secret.json:/config/client_secret.json:ro gilesknap/gphotos-sync --log-level DEBUG /storage
04-24 16:04:52 WARNING  gphotos-sync 2.14.0 2020-04-24 16:04:52.522195
04-24 16:04:52 DEBUG    MINIMUM_DATE = 1800-01-01 00:00:00
04-24 16:04:52 DEBUG    Checking if is filesystem supports symbolic links...
04-24 16:04:52 DEBUG    attempting to symlink /storage/test_src_1093115432 to /storage/test_dst_2633348676
04-24 16:04:52 DEBUG    Checking if File system supports unicode filenames...
04-24 16:04:52 INFO     Filesystem supports Unicode filenames
04-24 16:04:52 DEBUG    Checking if File system is case insensitive...
Traceback (most recent call last):
  File "/usr/local/bin/gphotos-sync", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/gphotos/Main.py", line 432, in main
    GooglePhotosSyncMain().main()
  File "/usr/local/lib/python3.7/site-packages/gphotos/Main.py", line 400, in main
    args = self.fs_checks(root_folder, args)
  File "/usr/local/lib/python3.7/site-packages/gphotos/Main.py", line 375, in fs_checks
    do_check(root_folder, int(args.max_filename), bool(args.ntfs))
  File "/usr/local/lib/python3.7/site-packages/gphotos/Checks.py", line 180, in do_check
    root_folder = Checks(root, max_filename, ntfs)
  File "/usr/local/lib/python3.7/site-packages/gphotos/Checks.py", line 35, in __init__
    self.is_case_sensitive: bool = self._check_case_sensitive()
  File "/usr/local/lib/python3.7/site-packages/gphotos/Checks.py", line 104, in _check_case_sensitive
    no_case_file.touch()
  File "/usr/local/lib/python3.7/pathlib.py", line 1258, in touch
    fd = self._raw_open(flags, mode)
  File "/usr/local/lib/python3.7/pathlib.py", line 1067, in _raw_open
    return self._accessor.open(self, flags, mode)
FileExistsError: [Errno 17] File exists: '/storage/.gphotos_check/TEMP.TEST'
````