### PR TITLE
handle exception 'OSError: [Errno 36] File name too long'

### DIFF
--- a/gphotos/GooglePhotosDownload.py
+++ b/gphotos/GooglePhotosDownload.py
@@ -153,8 +153,11 @@ class GooglePhotosDownload(object):
                         # skip files with filenames too long for this OS.
                         # probably thrown by local_full_path.exists().
                         errname = type(err).__name__
-                        if errname == 'OSError' and err.errno == errno.ENAMETOOLONG:
-                            log.warning("SKIPPED file because name is too long for this OS %s", local_full_path);
+                        if errname == "OSError" and err.errno == errno.ENAMETOOLONG:
+                            log.warning(
+                                "SKIPPED file because name is too long for this OS %s",
+                                local_full_path,
+                            )
                             self.files_download_failed += 1
                         else:
                             # re-raise other errors

--- a/gphotos/GooglePhotosDownload.py
+++ b/gphotos/GooglePhotosDownload.py
@@ -22,6 +22,7 @@ import requests
 from requests.exceptions import RequestException
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+import errno
 
 try:
     import win32file  # noqa
@@ -133,19 +134,31 @@ class GooglePhotosDownload(object):
                     local_folder = self._root_folder / relative_folder
                     local_full_path = local_folder / filename
 
-                    if local_full_path.exists():
-                        self.files_download_skipped += 1
-                        log.debug(
-                            "SKIPPED download (file exists) %d %s",
-                            self.files_download_skipped,
-                            media_item.relative_path,
-                        )
-                        self._db.put_downloaded(media_item.id)
+                    try:
+                        if local_full_path.exists():
+                            self.files_download_skipped += 1
+                            log.debug(
+                                "SKIPPED download (file exists) %d %s",
+                                self.files_download_skipped,
+                                media_item.relative_path,
+                            )
+                            self._db.put_downloaded(media_item.id)
 
-                    elif self.bad_ids.check_id_ok(media_item.id):
-                        batch[media_item.id] = media_item
-                        if not local_folder.is_dir():
-                            local_folder.mkdir(parents=True)
+                        elif self.bad_ids.check_id_ok(media_item.id):
+                            batch[media_item.id] = media_item
+                            if not local_folder.is_dir():
+                                local_folder.mkdir(parents=True)
+
+                    except Exception as err:
+                        # skip files with filenames too long for this OS.
+                        # probably thrown by local_full_path.exists().
+                        errname = type(err).__name__
+                        if errname == 'OSError' and err.errno == errno.ENAMETOOLONG:
+                            log.warning("SKIPPED file because name is too long for this OS %s", local_full_path);
+                            self.files_download_failed += 1
+                        else:
+                            # re-raise other errors
+                            raise
 
                 if len(batch) > 0:
                     self.download_batch(batch)


### PR DESCRIPTION
I received this exception on Linux Mint 19 (Tara) Cinnamon on an ext4 filesystem for two files, each with length of 266 characters including full path. This patch catches that exception specifically, skips the file, and logs a warning. I considered renaming the file to a shorter length of 64 random alphanumeric characters, but I don't know the codebase well enough to know if that would cause sync problems for future executions.

# /home/ejung/gphotos-sync/target/photos/2015/09/g0GCISQrWikYJJn33q3pqTO1yxJDvATd_p4hbeOHirSxEylcwybIKHUXUPDjovIlRKe9lD0hYLykJhoRbAn1KhS91LOuzbrovi6il9yuNqsFWkKELe5cN0ZuDcscu7RysScNfRbl-JGxYWbd0FFEGDAwh4H6ja8XD_X2f2qqI3_qrkABln05tllTc8szRFXgPA0ThAUqxzBlu_OByUDvB6.jpg
# /home/ejung/gphotos-sync/target/photos/2015/09/d7MFzdd5Xttmd5rl_RKjj_48Hskc8p72aYZAva9eB_uEvDmLum05hP15dAz6zN8RQmOp_ofZTbV6OTFZziwTJQ7owk4rji3hMKLoMN3ywMqBozkLK0jbvAcgrUM_ivB2s476vNiXu7Fh4qhdmlqO7PFCPgRAnEmDCUpWRCND_RJwsx7g5cF4z82BC4iPBMQvOT369sq9kVbK7s3tHNckrl.jpg