### PR TITLE
Make docker image lighter with alpine and multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,28 @@
-FROM python:3.7-buster
+FROM python:3-alpine AS gphotos-sync-builder
 
-RUN mkdir -p /root/.config /config
-RUN ln -s /config /root/.config/gphotos-sync 
+RUN apk add --update --no-cache gcc musl-dev linux-headers \
+	&& rm -rf /var/cache/apk/*
+
+ENV PYTHONDONTWRITEBYTECODE=1
+
+RUN python -m venv --system-site-packages /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN pip install --no-cache-dir --upgrade gphotos-sync
+
+FROM python:3-alpine
+
+COPY --from=gphotos-sync-builder /opt/venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN mkdir -p /root/.config /config \
+    && ln -s /config /root/.config/gphotos-sync \
+    && mkdir /storage
+
 VOLUME /config
 
-RUN mkdir /storage
 VOLUME /storage
-
-RUN pip install gphotos-sync
 
 ENTRYPOINT [ "gphotos-sync" ]


### PR DESCRIPTION
This PR aims at making the docker image lighter:

- python:3-alpine as a base image
- Multi-stage build to avoid embedding build environment in image
- Fewer layers

Keeping the build stage layers clean is probably a bit overkill, but hey.