### PR TITLE
Fix to symlinks on NTFS

### DIFF
--- a/gphotos/GoogleAlbumsSync.py
+++ b/gphotos/GoogleAlbumsSync.py
@@ -62,6 +62,7 @@ class GoogleAlbumsSync(object):
         self._use_flat_path = settings.use_flat_path
         self._omit_album_date = settings.omit_album_date
         self._use_hardlinks = settings.use_hardlinks
+        self._ntfs_override = settings.ntfs_override
 
     @classmethod
     def make_search_parameters(cls, album_id: str, page_token: str = None) -> Dict:
@@ -313,6 +314,8 @@ class GoogleAlbumsSync(object):
                 if full_file_name.exists():
                     if self._use_hardlinks:
                         os.link(full_file_name, link_file)
+                    elif self._ntfs_override:
+                        os.symlink(relative_filename, link_file)
                     else:
                         link_file.symlink_to(relative_filename)
                 else:

--- a/gphotos/Main.py
+++ b/gphotos/Main.py
@@ -314,6 +314,7 @@ class GooglePhotosSyncMain:
             omit_album_date=args.omit_album_date,
             use_hardlinks=args.use_hardlinks,
             progress=args.progress,
+            ntfs_override=args.ntfs
         )
 
         self.google_photos_client = RestClient(photos_api_url, self.auth.session)
@@ -385,8 +386,10 @@ class GooglePhotosSyncMain:
         do_check(root_folder, int(args.max_filename), bool(args.ntfs))
 
         # check if symlinks are supported
-        if not get_check().is_symlink:
-            args.skip_albums = True
+        # NTFS supports symlinks, but is_symlink() fails
+        if not args.ntfs:
+            if not get_check().is_symlink:
+                args.skip_albums = True
 
         # check if file system is case sensitive
         if not args.case_insensitive_fs:

--- a/gphotos/Settings.py
+++ b/gphotos/Settings.py
@@ -35,3 +35,5 @@ class Settings:
     max_threads: int
     case_insensitive_fs: bool
     progress: bool
+
+    ntfs_override: bool


### PR DESCRIPTION
The symlink support test failed on python 3.8.6/Win10/NTFS as for some reason Path.symlink_to() doesn't work properly. This meant that albums were skipped (args.skip_albums=True).

Looking deeper, I noticed that os.symlink() works as expected and considered changing the Path.symlink_to() calls with os.symlink(), but as I don't have time to test all possible side effects on different OS/filesystem combinations, I used the already existing --ntfs flag to make Win10/NTFS combination to work.

The --ntfs flag now enables symlink support and bypasses the check. Similarly, in the album creation routine, the flag forces the use of os.symlink() instead of Path.symlink_to(). The latter is used as before, if the --ntfs flag is not set.

However, I don't know what happens if you run this on Linux/MacOS and have somehow mounted an NTFS disk. Tested only on Win10/NTFS combination.