### PR TITLE
Output exception details when failing to link

### DIFF
--- a/gphotos/GoogleAlbumsSync.py
+++ b/gphotos/GoogleAlbumsSync.py
@@ -341,7 +341,7 @@ class GoogleAlbumsSync(object):
                     except PermissionError:
                         log.debug(f"cant set date on {link_file}")
 
-            except (FileExistsError, UnicodeEncodeError):
-                log.error("bad link to %s", full_file_name)
+            except (FileExistsError, UnicodeEncodeError) as err:
+                log.error("bad link to %s: %s", full_file_name, err)
 
         log.warning("Created %d new album folder links", count)


### PR DESCRIPTION
This error is common when you have albums with duplicate names, so
getting more details about the error makes it easier to diagnose.

Sample output looks roughly like so for FileExistsError:

    ERROR bad link to photos/YYYY/MM/filename.jpg:
    [Errno 17] File exists: 'photos/YYYY/MM/filename.jpg' ->
    albums/YYYY/Album Name/filename.jpg