### PR TITLE
Add a tip for naming the OAuth app name

### DIFF
--- a/docs/google-project-setup.rst
+++ b/docs/google-project-setup.rst
@@ -54,7 +54,8 @@ Configure OAuth Consent
 #. App Registration - OAuth consent screen:
 
    #. Set your **App Name**. For example, "Photos Sync". Note that this does
-      **not** have to be the same as the project name.
+      **not** have to be the same as the project name. Do not include "Google"
+      in the name or this will fail.
    #. Enter your email address as the **User support email**.
    #. Enter your email address as the **Developer contact information**.
    #. Add other fields as desired (they can be left blank).


### PR DESCRIPTION
I attempted to create an OAuth consent screen for an app with the name "Google Photos Sync" and received an error stating "An error saving your app has occurred." Inspecting the API call revealed this is not allowed: https://groups.google.com/g/google-cloud-dev/c/49yA4oOeSEs