### PR TITLE
Add note about photo compression and link to relevant issue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ to Google and this project will be updated once they are resolved.
 
   - https://issuetracker.google.com/issues/80149160
 
-- Photo download compresses the videos even if you ask for the original file (=d parameter).
+- Photo download compresses the photos even if you ask for the original file (=d parameter).
   This is similar to the above issue, except in my experience is is nearly impossible to notice a loss in quality. It
   is a file compressed to approximately 60% of the original size (same resolution).
 

--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,12 @@ to Google and this project will be updated once they are resolved.
 
   - https://issuetracker.google.com/issues/80149160
 
+- Photo download compresses the videos even if you ask for the original file (=d parameter).
+  This is similar to the above issue, except in my experience is is nearly impossible to notice a loss in quality. It
+  is a file compressed to approximately 60% of the original size (same resolution).
+
+  - https://issuetracker.google.com/issues/112096115
+
 - Burst shots are not supported. You will only see the first file of a burst shot.
 
   - https://issuetracker.google.com/issues/124656564


### PR DESCRIPTION
From my experience, a photo viewed in the Google Photos website shows the photo is 4.5 MB at 3000x4000 resolution. Downloading this file from the website shows the file is ~4,500,000 bytes at the same resolution. The same photo downloaded via gphotos-sync is only ~2,720,000 bytes (~60% original size) at the same resolution. I couldn't find any difference in the files side by side on my computer monitor even at 400% zoom.