### PR TITLE
Allow the inversion of the file order in albums.

### DIFF
--- a/gphotos/GoogleAlbumsSync.py
+++ b/gphotos/GoogleAlbumsSync.py
@@ -61,6 +61,7 @@ class GoogleAlbumsSync(object):
         self.include_video = settings.include_video
         self._use_flat_path = settings.use_flat_path
         self._omit_album_date = settings.omit_album_date
+        self._album_invert = settings.album_invert
         self._use_hardlinks = settings.use_hardlinks
         self._ntfs_override = settings.ntfs_override
 
@@ -276,7 +277,7 @@ class GoogleAlbumsSync(object):
             end_date_str,
             rid,
             created,
-        ) in self._db.get_album_files(download_again=re_download):
+        ) in self._db.get_album_files(album_invert=self._album_invert, download_again=re_download):
             if current_rid == rid:
                 album_item += 1
             else:

--- a/gphotos/LocalData.py
+++ b/gphotos/LocalData.py
@@ -321,13 +321,14 @@ class LocalData:
         )
 
     def get_album_files(
-        self, album_id: str = "%", download_again: bool = False
+        self, album_id: str = "%", album_invert: bool = False, download_again: bool = False
     ) -> (str, str, str, str, str, str):
         """ Join the Albums, SyncFiles and AlbumFiles tables to get a list
         of the files in an album or all albums.
         Parameters
             album_id: the Google Photos unique id for an album or None for all
             albums
+            album_invert: inverses the sorting direction of the returned files
         Returns:
             A tuple containing:
                 Path, Filename, AlbumName, Album end date
@@ -343,9 +344,10 @@ class LocalData:
         INNER JOIN Albums ON AlbumFiles.AlbumRec=Albums.RemoteId
         WHERE Albums.RemoteId LIKE ?
         {}
-        ORDER BY Albums.RemoteId, AlbumFiles.Position,
+        ORDER BY Albums.RemoteId, AlbumFiles.Position {},
         SyncFiles.CreateDate;""".format(
-            extra_clauses
+            extra_clauses,
+            "DESC" if album_invert else "ASC"
         )
 
         self.cur.execute(query, (album_id,))

--- a/gphotos/Main.py
+++ b/gphotos/Main.py
@@ -177,6 +177,12 @@ class GooglePhotosSyncMain:
         action="store_true",
         help="Don't include year and month in album folder names.",
     )
+    parser.add_argument(
+        "--album-invert",
+        action="store_true",
+        help="Inverts the sorting direction of files within an album. "
+        "Default sorting is descending from newest to olders. This causes it to be the other way around.",
+    )
     parser.add_argument("--new-token", action="store_true", help="Request new token")
     parser.add_argument(
         "--index-only",
@@ -312,6 +318,7 @@ class GooglePhotosSyncMain:
             max_retries=int(args.max_retries),
             max_threads=int(args.max_threads),
             omit_album_date=args.omit_album_date,
+            album_invert=args.album_invert,
             use_hardlinks=args.use_hardlinks,
             progress=args.progress,
             ntfs_override=args.ntfs

--- a/gphotos/Settings.py
+++ b/gphotos/Settings.py
@@ -20,6 +20,7 @@ class Settings:
     albums_path: Path
     album_index: bool
     omit_album_date: bool
+    album_invert: bool
     album: str
     album_regex: str
     shared_albums: bool


### PR DESCRIPTION
This is primarily useful to keep the filenames stable.
Google Photos by default gives the latest photo the "first" position.
This results in all symlinks renaming if new album photos appear.
With this flag, old pictures will mostly keep their name and new ones
will get higher number prefixes as long as no photos are added in the
middle of a timeline, which is pretty rare for auto-uploaded photos.