### PR TITLE
Change skipped files log message to WARNING

### DIFF
--- a/src/gphotos_sync/BadIds.py
+++ b/src/gphotos_sync/BadIds.py
@@ -53,7 +53,7 @@ class BadIds:
 
     def report(self):
         if self.bad_ids_found > 0:
-            log.error(
+            log.warning(
                 "WARNING: skipped %d files listed in %s",
                 self.bad_ids_found,
                 self.bad_ids_filename,


### PR DESCRIPTION
Change the log level of the `WARNING: skipped N files listed in /storage/gphotos.bad_ids.yaml` message to `WARNING` instead of `ERROR`. This seems more appropriate since this isn't considered an error condition.

I run `gphotos-sync` in cron and have my log level set to `ERROR`, this log message causes cron to send me an email every day, which would be nice to fix if possible.