### PR TITLE
Tidy up in 2023

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   lint:
+    # pull requests are a duplicate of a branch push if within the same repo.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: "ubuntu-latest"
     steps:
       - name: checkout
@@ -57,6 +59,7 @@ jobs:
         run: pipx run --python $(which python${{ matrix.python }}) --spec dist/*.whl ${GITHUB_REPOSITORY##*/} --version
 
   test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
@@ -219,7 +222,8 @@ jobs:
           file: .devcontainer/Dockerfile
           context: .
           platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
-          push: ${{ github.event_name != 'pull_request' }}
+          # only push tagged builds
+          push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
           build-args: BASE=python:3.10-slim
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -19,6 +19,7 @@ jobs:
           tox -e pre-commit,mypy
 
   wheel:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -2,13 +2,6 @@ name: Code CI
 
 on:
   push:
-    branches:
-      # Restricting to these branches and tags stops duplicate jobs on internal
-      # PRs but stops CI running on internal branches without a PR. Delete the
-      # next 5 lines to restore the original behaviour
-      - main
-    tags:
-      - "*"
   pull_request:
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   docs:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +35,7 @@ jobs:
         # Can delete this if you don't use graphviz in your docs
         run: sudo apt-get install graphviz
 
-      - name: checkout 
+      - name: checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -11,7 +11,7 @@ This is the internal code reference for gphotos_sync
 .. data:: gphotos_sync.__version__
     :type: str
 
-    Version number as calculated by https://github.com/gilesknap-org/versiongit
+    Version number as calculated by setuptools_scm
 
 .. automodule:: gphotos_sync.Main
     :members:

--- a/docs/tutorials/oauth2.rst
+++ b/docs/tutorials/oauth2.rst
@@ -16,9 +16,9 @@ For a discussion of the purpose of this ID see `Tokens`.
 Each step here assumes that you're logged into a personal Google account.
 
 .. note::
-   The steps outlined here are correct as of May 2022. Their is quite a 
-   bit of churn in the Google Cloud Console UI so the screens may change a 
-   bit. 
+   The steps outlined here are correct as of May 2022. Their is quite a
+   bit of churn in the Google Cloud Console UI so the screens may change a
+   bit.
 
 
 Create a Google Cloud Project
@@ -32,17 +32,17 @@ Create a Google Cloud Project
     .. image:: oauth-images/0.png
         :align: center
         :scale: 100 %
-  
+
 #. In the top banner the currently selected project is shown. If you have
    no previous projects this will say 'Select a project'
 
    * Click on the current project name or 'Select a project'
 
    * This will bring up the 'Select a Project' dialog
- 
+
     .. image:: oauth-images/1.png
         :align: center
-        :scale: 100  
+        :scale: 100
 
 #. Press **New Project**.
 #. Enter a project name. For example, "gphotos". This name must be unique
@@ -147,7 +147,7 @@ Create the OAuth Credentials
         :align: center
         :scale: 75
 
-#. Choose Desktop App 
+#. Choose Desktop App
     #. Choose name for your credentials e.g. gphotos
     #. Click **Create**
 
@@ -155,7 +155,7 @@ Create the OAuth Credentials
         :align: center
         :scale: 75
 
-#. Click **Download JSON** to download the OAuth client ID as JSON and 
+#. Click **Download JSON** to download the OAuth client ID as JSON and
    save it as ``client_secret.json``.
 
     .. image:: oauth-images/15-created.png
@@ -181,13 +181,13 @@ found in the README_.
 
 .. _`the Google Cloud docs`: https://developers.google.com/identity/protocols/oauth2#expiration
 .. _`Issue #290`: https://github.com/gilesknap/gphotos-sync/issues/290
-.. _README: https://github.com/gilesknap/gphotos-sync/README.rst
+.. _README: https://github.com/gilesknap/gphotos-sync/blob/main/README.rst
 
 
 Move client_secret.json
 -----------------------
 
     #. The client_secret.json must be moved to the correct location
-    #. Each supported operating system has a different location where it will 
+    #. Each supported operating system has a different location where it will
        look for this file.
     #. Return the `Tutorial` for details of where to put this file.

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,15 +29,13 @@ setup_requires =
     setuptools_scm[toml]>=6.2
 
 install_requires =
-    attrs
-    exif
-    appdirs
-    requests_oauthlib
-    pyyaml>=4.2b1
+    attrs==22.2.0
+    exif==1.6.0
+    appdirs==1.4.4
+    pyyaml==6.0
     types-PyYAML
-    psutil
-    google-auth-oauthlib>=1.0.0
-    types-requests
+    psutil==5.9.4
+    google-auth-oauthlib==1.0.0
 
 [options.extras_require]
 # For development tests/docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ install_requires =
     exif==1.6.0
     appdirs==1.4.4
     pyyaml==6.0
-    types-PyYAML
     psutil==5.9.4
     google-auth-oauthlib==1.0.0
 
@@ -52,6 +51,8 @@ dev =
     setuptools_scm[toml]>=6.2
     mock
     types-setuptools
+    types-requests
+    types-PyYAML
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ dev =
     pytest-cov
     sphinx-rtd-theme-github-versions
     tox
+    tox-direct
     setuptools_scm[toml]>=6.2
     mock
     types-setuptools
@@ -120,20 +121,20 @@ source =
 # Hence the use of allowlist_externals instead of using the tox virtualenvs.
 # This ensures a match between developer time tools in the IDE and tox tools.
 [tox:tox]
-minversion = 3.7
-skipsdist=true
-skipinstall=true
+skipsdist = True
 
 [testenv:{pre-commit,mypy,pytest,docs}]
-setenv =
-    QT_QPA_PLATFORM = offscreen
+# Don't create a virtualenv for the command, requires tox-direct plugin
+direct = True
+passenv = *
 allowlist_externals =
     pytest
     pre-commit
     mypy
     sphinx-build
+    sphinx-autobuild
 commands =
-    pytest: pytest tests {posargs}
+    pytest: pytest {posargs}
     mypy: mypy src tests {posargs}
     pre-commit: pre-commit run --all-files {posargs}
-    docs: sphinx-build -EWT --keep-going docs build/html {posargs}
+    docs: sphinx-{posargs:build -EW --keep-going} -T docs build/html

--- a/src/gphotos_sync/GooglePhotosDownload.py
+++ b/src/gphotos_sync/GooglePhotosDownload.py
@@ -70,8 +70,8 @@ class GooglePhotosDownload(object):
         self.end_date: datetime = settings.end_date
         self.retry_download: bool = settings.retry_download
         self.case_insensitive_fs: bool = settings.case_insensitive_fs
-        self.video_timeout: int = 2000
-        self.image_timeout: int = 60
+        self.video_timeout: int = settings.video_timeout
+        self.image_timeout: int = settings.image_timeout
 
         # attributes related to multi-threaded download
         self.download_pool = futures.ThreadPoolExecutor(max_workers=self.max_threads)

--- a/src/gphotos_sync/Main.py
+++ b/src/gphotos_sync/Main.py
@@ -303,6 +303,18 @@ class GooglePhotosSyncMain:
         type=int,
         default=8080,
     )
+    parser.add_argument(
+        "--image-timeout",
+        help="Set the time in seconds to wait for an image to download",
+        type=int,
+        default=60,
+    )
+    parser.add_argument(
+        "--video-timeout",
+        help="Set the time in seconds to wait for a video to download",
+        type=int,
+        default=2000,
+    )
     parser.add_help = True
 
     def setup(self, args: Namespace, db_path: Path):
@@ -366,6 +378,8 @@ class GooglePhotosSyncMain:
             ntfs_override=args.ntfs,
             month_format=args.month_format,
             path_format=args.path_format,
+            image_timeout=args.image_timeout,
+            video_timeout=args.video_timeout,
         )
 
         self.google_photos_client = RestClient(

--- a/src/gphotos_sync/Settings.py
+++ b/src/gphotos_sync/Settings.py
@@ -46,3 +46,6 @@ class Settings:
 
     month_format: str
     path_format: str
+
+    image_timeout: int
+    video_timeout: int


### PR DESCRIPTION
[dont push containers unless tagged](https://github.com/gilesknap/gphotos-sync/pull/418/commits/69373406d1966499bc121c0b23b5f07508818cfd)
[6937340](https://github.com/gilesknap/gphotos-sync/pull/418/commits/69373406d1966499bc121c0b23b5f07508818cfd)
@gilesknap
[pin all runtime dependencies as this is an app](https://github.com/gilesknap/gphotos-sync/pull/418/commits/e074651149e744d11fdf804d154720e18ea84bbe)
[e074651](https://github.com/gilesknap/gphotos-sync/pull/418/commits/e074651149e744d11fdf804d154720e18ea84bbe)
@gilesknap
[run CI on branches but avoid duplicate runs on PR](https://github.com/gilesknap/gphotos-sync/pull/418/commits/64e512d3ee90f08d3b119c7f8149c934728bcb21)
[64e512d](https://github.com/gilesknap/gphotos-sync/pull/418/commits/64e512d3ee90f08d3b119c7f8149c934728bcb21)
@gilesknap
[add --video-timeout and --image-timeout](https://github.com/gilesknap/gphotos-sync/pull/418/commits/f7e587d599018c851b176e5025a33ea9b08fd87f)
[f7e587d](https://github.com/gilesknap/gphotos-sync/pull/418/commits/f7e587d599018c851b176e5025a33ea9b08fd87f)
@gilesknap
[fix docs links and CI](https://github.com/gilesknap/gphotos-sync/pull/418/commits/abf991f21037365202f68dae6e5b5fc51604bb7c)