### PR TITLE
Incorrect timezone

### DIFF
--- a/src/gphotos_sync/authorize.py
+++ b/src/gphotos_sync/authorize.py
@@ -77,12 +77,9 @@ class Authorize:
         self.token_file.chmod(0o600)
 
     def convert_to_local_timestamp(self, dt):
-        dt = dt.astimezone()
-        tz_offset = 86400 - dt.tzinfo.utcoffset(dt).seconds
-        # Daylight Savings Time
         is_dst = time.localtime().tm_isdst
-        tz_offset = tz_offset + 3600 if is_dst else tz_offset
-        return dt.timestamp() - tz_offset
+        offset = time.timezone - 3600 if is_dst else time.timezone
+        return dt.timestamp() - offset
 
     def authorize(self):
         """Initiates OAuth2 authentication and authorization flow"""

--- a/src/gphotos_sync/authorize.py
+++ b/src/gphotos_sync/authorize.py
@@ -110,7 +110,7 @@ class Authorize:
                 "refresh_token": flow.credentials.refresh_token,
                 "token_type": "Bearer",
                 "scope": flow.credentials.scopes,
-                "expires_at": self.convert_to_local_timestamp(flow.credentials.expiry),
+                "expires_at": flow.credentials.expiry.replace(tzinfo=timezone.utc).timestamp()
             }
 
             self.save_token(oauth2_token)

--- a/src/gphotos_sync/authorize.py
+++ b/src/gphotos_sync/authorize.py
@@ -2,7 +2,7 @@ import logging
 from json import JSONDecodeError, dump, load
 from pathlib import Path
 from typing import List, Optional
-import time
+from datetime import timezone
 
 from google_auth_oauthlib.flow import InstalledAppFlow
 from requests.adapters import HTTPAdapter
@@ -75,11 +75,6 @@ class Authorize:
         with self.token_file.open("w") as stream:
             dump(token, stream)
         self.token_file.chmod(0o600)
-
-    def convert_to_local_timestamp(self, dt):
-        is_dst = time.localtime().tm_isdst
-        offset = time.timezone - 3600 if is_dst else time.timezone
-        return dt.timestamp() - offset
 
     def authorize(self):
         """Initiates OAuth2 authentication and authorization flow"""


### PR DESCRIPTION
for issue: https://github.com/gilesknap/gphotos-sync/issues/413 , basically all this does is get the system timezone offset in seconds from `time.timezone` and subtracts it from expiry.timestamp. Also accounts for DST.