### PR TITLE
Protect BadIds.py from an empty bad ids file.

### DIFF
--- a/src/gphotos_sync/BadIds.py
+++ b/src/gphotos_sync/BadIds.py
@@ -30,7 +30,7 @@ class BadIds:
     def load_ids(self):
         try:
             with self.bad_ids_filename.open("r") as stream:
-                self.items = safe_load(stream)
+                self.items = safe_load(stream) or {}
             log.debug("bad_ids file, loaded %d bad ids", len(self.items))
         except (YAMLError, IOError):
             log.debug("no bad_ids file, bad ids list is empty")

--- a/tests/test_boilerplate_removed.py
+++ b/tests/test_boilerplate_removed.py
@@ -2,6 +2,7 @@
 This file checks that all the example boilerplate text has been removed.
 It can be deleted when all the contained tests pass
 """
+
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
When the bad ids file is empty (which could happen if the process is interrupted at an inopportune moment, then when the process next starts and attempts to read the file, there will be a crash due to accessing the length of a NoneType. safe_load returns None when the content of the file is empty.