### PR TITLE
added an option "no-album-sorting" to remove the prefixes in albums

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,8 @@ commands =
 [tool.ruff]
 src = ["src", "tests"]
 line-length = 88
+
+[tool.ruff.lint]
 select = [
     "C4",   # flake8-comprehensions - https://beta.ruff.rs/docs/rules/#flake8-comprehensions-c4
     "E",    # pycodestyle errors - https://beta.ruff.rs/docs/rules/#error-e

--- a/src/gphotos_sync/GoogleAlbumsSync.py
+++ b/src/gphotos_sync/GoogleAlbumsSync.py
@@ -66,6 +66,7 @@ class GoogleAlbumsSync(object):
         self._ntfs_override = settings.ntfs_override
         self.month_format = settings.month_format
         self.path_format = settings.path_format
+        self._no_album_sorting = settings.no_album_sorting
 
     @classmethod
     def make_search_parameters(
@@ -309,7 +310,11 @@ class GoogleAlbumsSync(object):
 
             link_folder: Path = self.album_folder_name(album_name, start_date, end_date)
 
-            link_filename = "{:04d}_{}".format(album_item, file_name)
+            if self._no_album_sorting:
+                link_filename = "{}".format(file_name)
+            else:
+                link_filename = "{:04d}_{}".format(album_item, file_name)
+
             link_filename = link_filename[: get_check().max_filename]
             link_file = link_folder / link_filename
             # incredibly, pathlib.Path.relative_to cannot handle

--- a/src/gphotos_sync/Settings.py
+++ b/src/gphotos_sync/Settings.py
@@ -26,6 +26,7 @@ class Settings:
     album_index: bool
     omit_album_date: bool
     album_invert: bool
+    no_album_sorting: bool
     album: str
     album_regex: str
     shared_albums: bool

--- a/src/gphotos_sync/__main__.py
+++ b/src/gphotos_sync/__main__.py
@@ -148,6 +148,11 @@ class GooglePhotosSyncMain:
         "photo. The default is its last photo",
     )
     parser.add_argument(
+        "--no-album-sorting",
+        action="store_true",
+        help="Remove prefix in photo filename inside the album folders",
+    )
+    parser.add_argument(
         "--start-date",
         help="Set the earliest date of files to sync" "format YYYY-MM-DD",
         default=None,
@@ -380,6 +385,7 @@ class GooglePhotosSyncMain:
             path_format=args.path_format,
             image_timeout=args.image_timeout,
             video_timeout=args.video_timeout,
+            no_album_sorting=args.no_album_sorting,
         )
 
         self.google_photos_client = RestClient(

--- a/tests/test_units/test_units.py
+++ b/tests/test_units/test_units.py
@@ -185,4 +185,4 @@ class TestUnits(TestCase):
                 )
                 s.gp.fs_checks(s.root, s.parsed_args)
                 self.assertTrue(get_check().is_linux)
-                self.assertEqual(get_check().max_filename, 255)
+                self.assertTrue(get_check().max_filename >= 242)


### PR DESCRIPTION
added an option "no-album-sorting" to remove the prefixes added to  the photos inside an album so that the names are identical to the original photos names