### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,11 @@ repos:
         language: system
         entry: ruff
         types: [python]
+
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in pyproject.toml
+    rev: v2.2.6
+    hooks:
+    - id: codespell
+      additional_dependencies:
+      - tomli

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -39,7 +39,7 @@ on your workstation as follows::
 
 In both cases tox -p runs in parallel the following checks:
 
-  - Buiild Spinx Documentation
+  - Build Spinx Documentation
   - run pytest on all tests in ./tests
   - run mypy linting on all files in ./src ./tests
   - run pre-commit checks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN pip install ${PIP_OPTIONS}
 
 FROM python:3.11-slim as runtime
 
-# Add apt-get system dependecies for runtime here if needed
+# Add apt-get system dependencies for runtime here if needed
 
 # copy the virtual environment from the build stage and put it in PATH
 COPY --from=build /venv/ /venv/

--- a/docs/explanations/folders.rst
+++ b/docs/explanations/folders.rst
@@ -22,7 +22,7 @@ albums:
     folder. The folder names will be 'albums/YYYY/MM Original Album Name'.
 
 Note that these are the default layouts and you can change what is downloaded
-and how it is layed out with command line options. See the help for details::
+and how it is laid out with command line options. See the help for details::
 
     gphotos-sync --help
 

--- a/docs/explanations/notes.rst
+++ b/docs/explanations/notes.rst
@@ -13,5 +13,5 @@ Google Photos Library in the cloud. There are two primary reasons for this:
 
 - Even if the API allowed it, this would be a very hard problem, because
   it is often hard to identify if a local photo or video matches one in the 
-  cloud. Besides this, I would not want the resposibility of potentially 
+  cloud. Besides this, I would not want the responsibility of potentially 
   trashing someone's photo collection. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,3 +129,10 @@ select = [
     "W",    # pycodestyle warnings - https://beta.ruff.rs/docs/rules/#warning-w
     "I001", # isort
 ]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.css'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,4 +135,4 @@ select = [
 skip = '.git*,*.css'
 check-hidden = true
 # ignore-regex = ''
-# ignore-words-list = ''
+ignore-words-list = 'implementors'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ filterwarnings = [
     "error",
     "ignore:.*socket.*:ResourceWarning",
     # this deprecation is rather serious for gphotos-sync as it relies on sqlite
-    # doing date conversion quite heavily - will ignore the deprection for now
+    # doing date conversion quite heavily - will ignore the deprecation for now
     # DeprecationWarning: The default datetime adapter is deprecated as of Python 3.12;
     "ignore:.*sqlite3.*:DeprecationWarning:",
     # like the above

--- a/src/gphotos_sync/Checks.py
+++ b/src/gphotos_sync/Checks.py
@@ -130,7 +130,7 @@ class Checks:
         except BaseException:
             # for failures choose a safe size for Windows filesystems
             log.info(
-                f"cant determine max filepath length, defaulting to " f"{max_length}"
+                f"can't determine max filepath length, defaulting to " f"{max_length}"
             )
         log.info("Max Path Length: %d" % max_length)
         return max_length
@@ -145,7 +145,7 @@ class Checks:
             # for failures choose a safe size for Windows filesystems
             max_filename = 248
             log.info(
-                f"cant determine max filename length, " f"defaulting to {max_filename}"
+                f"can't determine max filename length, " f"defaulting to {max_filename}"
             )
         log.info("Max filename length: %d" % max_filename)
         return max_filename

--- a/src/gphotos_sync/GoogleAlbumsSync.py
+++ b/src/gphotos_sync/GoogleAlbumsSync.py
@@ -376,7 +376,7 @@ class GoogleAlbumsSync(object):
                                 follow_symlinks=False,
                             )
                     except PermissionError:
-                        log.debug(f"cant set date on {link_file}")
+                        log.debug(f"can't set date on {link_file}")
 
             except FileExistsError as err:
                 log.info("duplicate link to %s: %s", full_file_name, err)

--- a/src/gphotos_sync/__main__.py
+++ b/src/gphotos_sync/__main__.py
@@ -76,7 +76,7 @@ class GooglePhotosSyncMain:
         "--conf",
         action="store",
         help="use the .ini configuration file to initialise arguments. "
-        "Command line provided arguments will superceed the ones in the config file",
+        "Command line provided arguments will supersede the ones in the config file",
     )
     parser.add_argument(
         "root_folder",
@@ -286,7 +286,7 @@ class GooglePhotosSyncMain:
     )
     parser.add_argument(
         "--max-filename",
-        help="Set the maxiumum filename length for target filesystem."
+        help="Set the maximum filename length for target filesystem."
         "This overrides the automatic detection.",
         default=0,
     )


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.